### PR TITLE
CSS classes: similar to UI-Text to have a consistant UI experience

### DIFF
--- a/ui/components/UILed.vue
+++ b/ui/components/UILed.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="nrdb-ui-led" :style="`--ui-led-shadow-width: ${size * 0.1}px; --ui-led-border-width: ${size * 0.15}px; --ui-led-color: ${color}; flex-direction: ${flexDirection}`">
-        <label v-if="props.label" class="nrdb-ui-led-label v-label" :style="`justify-content: ${labelAlignment}`">{{ props.label }}</label>
+        <label v-if="props.label" class="nrdb-ui-led-label" :style="`justify-content: ${labelAlignment}`">{{ props.label }}</label>
         <span ref="led" class="nrdb-ui-led-bulb" :class="`${hasValue ? 'nrdb-ui-led-bulb-on' : ''} nrdb-ui-led-bulb--${props.shape} ${props.showGlow && hasValue ? 'nrdb-ui-led-bulb--glow' : ''} ${props.showBorder ? 'nrdb-ui-led-bulb--border' : ''}`">{{ value !== null ? value : 'No Message Received' }}</span>
     </div>
 </template>
@@ -93,6 +93,9 @@ export default {
 
 .nrdb-ui-led-label {
     flex-grow: 1;
+    font-size: 1rem;
+    color: #717171;
+    font-family: Helvetica;
 }
 
 .nrdb-ui-led-bulb {


### PR DESCRIPTION
## Description

The CSS class `nrdb-ui-led-label` is changed according to `ui-text`:
- in the template it is the only class; `v-lable` is removed
- the style definition is amended so that it is similar to `ui-text`

## Related Issue(s)

Closes https://github.com/FlowFuse/node-red-dashboard-2-ui-led/issues/6

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

