### PR TITLE
configure which msg property for the value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+*~

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The `ui-led` node has the following configuration options:
 <img width="500" alt="Screenshot 2024-02-17 at 10 02 43" src="https://github.com/FlowFuse/node-red-dashboard-2-ui-led/assets/99246719/8ed8de2a-d300-483d-a2c3-720fe296cf25">
 
 - **Name**: The name of the node within the context of the Node-RED editor.
+- **Value**: Configure how the value is determined. Can be set to use a specific message property. If not configured, defaults to `msg.payload`.
 - **Group**: The UI Group that the LED will render inside.
 - **Size**: The relative size of the LED with `width` x `height`
 

--- a/README.md
+++ b/README.md
@@ -36,4 +36,5 @@ The `ui-led` node has the following configuration options:
 
 <img width="500" alt="Screenshot 2024-02-17 at 10 01 44" src="https://github.com/FlowFuse/node-red-dashboard-2-ui-led/assets/99246719/debe5d84-454f-43f4-82b9-a48f29b12307">
 
+- The value is a property of the message, e.g. `msg.payload` or `msg.myProperty`.
 - Maps a value to a respective color. If a value is provided that it doesn't recognise, a general grey color will be used.

--- a/nodes/locales/en-US/ui-led.html
+++ b/nodes/locales/en-US/ui-led.html
@@ -6,6 +6,10 @@
         <dd>The name of the node within the context of the Node-RED editor.</dd>
     </dl>
     <dl class="message-properties">
+        <dt>Value <span class="property-type">typed input</span></dt>
+        <dd>Configure how the value is determined. Can be set to use a specific message property. If not configured, defaults to <code>msg.payload</code>.</dd>   
+    </dl>
+    <dl class="message-properties">
         <dt>Group <span class="property-type">ui-group</span></dt>
         <dd>The UI Group that the LED will render inside.</dd>
     </dl>

--- a/nodes/ui-led.html
+++ b/nodes/ui-led.html
@@ -47,6 +47,7 @@
         color: RED._('@flowfuse/node-red-dashboard/ui-base:ui-base.colors.medium'),
         defaults: {
             name: { value: "" },
+            property:{ value: "payload", required: true },
             group: { type: 'ui-group', required: true },
             order: { value: -1 },
             width: {
@@ -88,7 +89,7 @@
         outputs: 0,
         icon: "font-awesome/fa-lightbulb-o",
         label: function() {
-            return this.name || "ui-led";
+            return this.name || this.label || "ui-led";
         },
         oneditprepare: function () {
             $('#node-input-size').elementSizer({
@@ -117,6 +118,16 @@
                 const state = this.states[i]
                 generateStateRow(i + 1, state)
             }
+            // property
+            if( this.property === undefined )
+            {
+                $("#node-input-property").val( "payload" );
+            }
+            $("#node-input-property").typedInput({
+                type:"msg",
+                types:["msg"],
+                typeField: "#node-input-property-type"
+            })
         },
         oneditsave: function () {
             const states = $('#node-input-states-container').children()
@@ -194,6 +205,11 @@
         </div>
     </div>
     <h3>Values</h3>
+    <div class="form-row">
+        <label for="node-input-input"><i class="fa fa-ellipsis-h"></i> Value</label>
+        <input type="text" id="node-input-property">
+        <input type="hidden" id="node-input-property-type">
+    </div>
     <div class="form-row node-input-states-container-row" style="margin-bottom:0px; width:100%; min-width:520px; display: flex; flex-direction: column;">
         <label style="vertical-align:top; width: 100%;"><i class="fa fa-list-alt"></i> Colors for value of msg.payload</label>
         <div id="node-input-states-container-div" style="box-sizing:border-box; border-radius:5px; height:257px; padding:5px; border:1px solid var(--red-ui-form-input-border-color, #ccc); overflow-y:scroll; display:inline-block; width: 100%;">

--- a/nodes/ui-led.js
+++ b/nodes/ui-led.js
@@ -3,6 +3,7 @@ module.exports = function (RED) {
         RED.nodes.createNode(this, config)
 
         const node = this
+        this.property = config.property || "payload";
 
         // which group are we rendering this widget
         const group = RED.nodes.getNode(config.group)
@@ -12,6 +13,9 @@ module.exports = function (RED) {
         // server-side event handlers
         const evts = {
             onInput: function (msg, send, done) {
+                // evaluate property parameter
+                msg.payload = RED.util.getMessageProperty( msg, node.property );
+
                 // store the latest value in our Node-RED datastore
                 base.stores.data.save(base, node, msg)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowfuse/node-red-dashboard-2-ui-led",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "A simple LED status indicator for the Node-RED Dashboard 2.0",
     "keywords": [
         "node-red",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mschaeffler/node-red-dashboard-2-ui-led",
-    "version": "1.2.1",
+    "version": "1.2.3",
     "description": "A simple LED status indicator for the Node-RED Dashboard 2.0",
     "keywords": [
         "node-red",
@@ -8,7 +8,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/mschaeffler/node-red-dashboard-2-ui-led.git"
+        "url": "https://github.com/m-schaeffler/node-red-dashboard-2-ui-led"
     },
     "license": "Apache-2.0",
     "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@flowfuse/node-red-dashboard-2-ui-led",
-    "version": "1.2.0",
+    "name": "@mschaeffler/node-red-dashboard-2-ui-led",
+    "version": "1.2.1",
     "description": "A simple LED status indicator for the Node-RED Dashboard 2.0",
     "keywords": [
         "node-red",
@@ -8,14 +8,19 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/FlowFuse/node-red-dashboard-2-ui-led.git"
+        "url": "https://github.com/mschaeffler/node-red-dashboard-2-ui-led.git"
     },
     "license": "Apache-2.0",
     "author": {
+        "name": "Mathias Schäffler",
+        "url": "https://github.com/mschaeffler"
+    },
+    "contributors": [
+      {
         "name": "Joe Pavitt",
         "url": "https://github.com/joepavitt"
-    },
-    "contributors": [],
+      }
+    ],
     "exports": {
         "import": "./resources/ui-led.esm.js",
         "require": "./resources/ui-led.umd.js"


### PR DESCRIPTION
## Description

- take the label for labeling the node in the editor
- add the possibility to configure which msg property is taken as the value.

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [x] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

