### PR TITLE
Fall back to gray when matching state has no color + document JSON schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,42 @@ The `ui-led` node has the following configuration options:
 
 <img width="500" alt="Screenshot 2024-02-17 at 10 01 44" src="https://github.com/FlowFuse/node-red-dashboard-2-ui-led/assets/99246719/debe5d84-454f-43f4-82b9-a48f29b12307">
 
-- Maps a value to a respective color. If a value is provided that it doesn't recognise, a general grey color will be used.
+- Maps a value to a respective color. If a value is provided that doesn't match any of the configured states, a general grey color is used. The same fallback applies if a matching state has been configured without a color.
+
+## JSON config (for hand-crafted flows and tooling)
+
+The editor calls this section "Values"; in the underlying node config the field is **`states`**. A typical config object looks like:
+
+```json
+{
+    "id": "97c1b0d2c8f4cb1a",
+    "type": "ui-led",
+    "group": "<ui-group-id>",
+    "order": 1,
+    "width": 1,
+    "height": 1,
+    "label": "Running",
+    "labelPlacement": "left",
+    "labelAlignment": "left",
+    "shape": "circle",
+    "showBorder": true,
+    "showGlow": true,
+    "allowColorForValueInMessage": false,
+    "states": [
+        { "value": "true",  "valueType": "bool", "color": "#28a745" },
+        { "value": "false", "valueType": "bool", "color": "#dc3545" }
+    ]
+}
+```
+
+The `states` array maps the incoming `msg.payload` to a CSS color:
+
+| Field | Meaning |
+|---|---|
+| `value` | The payload value to match against. Strings, since Node-RED's typed-input stores them that way. For `valueType: "bool"` use `"true"` / `"false"`; for `"num"` use the number as a string, e.g. `"42"`. |
+| `valueType` | The Node-RED typed-input type — typically `"bool"`, `"num"`, `"str"`, or `"json"`. Values are evaluated server-side at deploy time. |
+| `color` | Any CSS color value — hex, named, `rgb(...)`, etc. |
+
+`allowColorForValueInMessage: true` lets a flow override the color at runtime via `msg.color`.
+
+Note: the field name is `states` (the source of confusion for some users — including the FlowFuse engineering team when hand-crafting flow JSON or generating it from scripts/LLMs). It is *not* `colorForValue`.

--- a/ui/components/UILed.vue
+++ b/ui/components/UILed.vue
@@ -38,12 +38,15 @@ export default {
                 // check which, if any, color we should be displaying
                 for (const i in this.props.evaluated) {
                     const state = this.props.evaluated[i]
-                    if (typeof (state.value) === 'object') {
-                        if (JSON.stringify(state.value) === JSON.stringify(msg.payload)) {
-                            return state.color
-                        }
-                    } else if (state.value === msg.payload) {
-                        return state.color
+                    const matched = typeof state.value === 'object'
+                        ? JSON.stringify(state.value) === JSON.stringify(msg.payload)
+                        : state.value === msg.payload
+                    if (matched) {
+                        // Fall back to gray when the matching state has no color set.
+                        // Otherwise the CSS variable becomes the literal string "undefined"
+                        // and `background-color: var(--ui-led-color)` resolves to nothing,
+                        // making the bulb effectively invisible.
+                        return state.color || 'gray'
                     }
                 }
             }


### PR DESCRIPTION
## Problem

When `msg.payload` matches a configured state but that state has no `color` set, the computed `color` is `undefined`. That value is interpolated into the inline style as the literal string `--ui-led-color: undefined;`, which is an invalid CSS value, so `background-color: var(--ui-led-color)` resolves to nothing and **the bulb becomes invisible** — no warning in the console, no fallback color, just a label with empty space where the LED should be.

This is easy to hit in a few real scenarios:

- A flow is hand-crafted or generated by tooling (scripts, LLMs) and the author guesses the field name (`colorForValue`, `colours`, etc.) instead of the correct `states`. The widget then has zero rules, the `for` loop doesn't iterate, and the fallback `'gray'` kicks in — that case already works. BUT if they get the field name right but forget `color` on a state entry, the result is invisible.
- The editor's HTML defaults set up two `states` entries (`{value: false, valueType: 'bool'}` and `{value: true, valueType: 'bool'}`) **with no `color` field**. An engineer who deploys without opening the Values dialog gets invisible LEDs.
- A flow is imported from another instance where `color` was stripped (some flow editors / migration tools normalise default-equal fields out of stored JSON).

In all three cases the LED is silently invisible. We hit it on a customer engagement; the only diagnosis path was reading the Vue component source, which isn't ideal for users.

## Fix

`ui/components/UILed.vue`: when a state matches but `state.color` is falsy, return `'gray'` instead of `undefined`. Same fallback the function already uses for "no match found" and "no value received yet" — extends it to cover the "matched state, no color set" case so the bulb is *never* silently invisible.

Also restructures the match check into a single `matched` boolean to keep the result-resolution in one place.

No behaviour change for correctly-configured LEDs.

## Docs

`README.md`: adds a "JSON config" section documenting the underlying `states` field name. The editor labels this section "Values"; the underlying node property is `states`. This trips up users hand-editing flow JSON or generating it from scripts (including this engagement — several wrong guesses before reading the source).

Also reworded the existing "If a value is provided that it doesn't recognise" bullet to mention the missing-color fallback explicitly, matching the new behaviour.

## Testing

- Manual: deployed the change with a `ui-led` whose state entries lacked colors. Before: invisible. After: gray bulb (visibly there, just neutral).
- Existing LEDs with correct color config: unchanged — green/red/etc. still render as configured.
- The `gray` fallback fires in three independent code paths now: no value yet (existing), no state matches (existing), matching state has no color (new).

## Notes

- This stops short of changing the HTML defaults to include sensible `color` values for the default `states` (would change UX for existing users who currently see invisible LEDs but then add colors via the editor). Open to doing that as a follow-up if you think it's a clearer fix.